### PR TITLE
update broken logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://brimble.app" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://storage.googleapis.com/brimble-assets/logo_readme.svg" alt="Brimble logo">
+    <img width="180" src="https://res.cloudinary.com/crunchbase-production/image/upload/c_lpad,h_170,w_170,f_auto,b_white,q_auto:eco,dpr_1/o1qoh3j9wztndr9egkt9" alt="Brimble logo">
   </a>
 </p>
 


### PR DESCRIPTION
This commit gets the Brimble's logo from https://www.crunchbase.com/organization/brimble and updates it here ,since the previos logo was broken